### PR TITLE
adding support for skipping the install and build phases

### DIFF
--- a/configs/default_filter_config.json
+++ b/configs/default_filter_config.json
@@ -1,12 +1,14 @@
 {
 	"install": {
-		"timeout": 1000
+		"timeout": 1000,
+		"do_install": true
 	},
 	"dependencies": {
 		"track_deps": false,
 		"include_dev_deps": false
 	},
 	"build": {
+		"track_build": true,
 		"tracked_build_commands": ["build", "compile", "init"],
 		"timeout": 1000
 	},

--- a/src/diagnose_github_repo.py
+++ b/src/diagnose_github_repo.py
@@ -28,8 +28,10 @@ class RepoWalker():
 	SCRIPTS_OVER_CODE = []
 	QL_QUERIES = []
 
+	DO_INSTALL = True
 	INCLUDE_DEV_DEPS = False
 	COMPUTE_DEP_LISTS = False
+	TRACK_BUILD = True
 	TRACK_TESTS = True
 
 	TRACKED_TEST_COMMANDS = ["test", "unit", "cov", "ci", "integration", "lint", "travis", "e2e", "bench", 
@@ -83,9 +85,11 @@ class RepoWalker():
 		self.COMPUTE_DEP_LISTS = cf_dict.get("track_deps", self.COMPUTE_DEP_LISTS)
 
 		cf_dict = config_json.get( "install", {})
+		self.DO_INSTALL = cf_dict.get("do_install", self.DO_INSTALL)
 		self.INSTALL_TIMEOUT = cf_dict.get("timeout", self.INSTALL_TIMEOUT)
 
 		cf_dict = config_json.get( "build", {})
+		self.TRACK_BUILD = cf_dict.get("track_build", self.TRACK_BUILD)
 		self.BUILD_TIMEOUT = cf_dict.get("timeout", self.BUILD_TIMEOUT)
 		self.TRACKED_BUILD_COMMANDS = cf_dict.get("tracked_build_commands", self.TRACKED_BUILD_COMMANDS)
 

--- a/src/diagnose_npm_package.py
+++ b/src/diagnose_npm_package.py
@@ -21,8 +21,10 @@ class NPMSpider(scrapy.Spider):
 	SCRIPTS_OVER_CODE = []
 	QL_QUERIES = []
 
+	DO_INSTALL = True
 	INCLUDE_DEV_DEPS = False
 	COMPUTE_DEP_LISTS = False
+	TRACK_BUILD = True
 	TRACK_TESTS = True
 
 	TRACKED_TEST_COMMANDS = ["test", "unit", "cov", "ci", "integration", "lint", "travis", "e2e", "bench", 
@@ -75,9 +77,11 @@ class NPMSpider(scrapy.Spider):
 		self.COMPUTE_DEP_LISTS = cf_dict.get("track_deps", self.COMPUTE_DEP_LISTS)
 
 		cf_dict = config_json.get( "install", {})
+		self.DO_INSTALL = cf_dict.get("do_install", self.DO_INSTALL)
 		self.INSTALL_TIMEOUT = cf_dict.get("timeout", self.INSTALL_TIMEOUT)
 
 		cf_dict = config_json.get( "build", {})
+		self.TRACK_BUILD = cf_dict.get("track_build", self.TRACK_BUILD)
 		self.BUILD_TIMEOUT = cf_dict.get("timeout", self.BUILD_TIMEOUT)
 		self.TRACKED_BUILD_COMMANDS = cf_dict.get("tracked_build_commands", self.TRACKED_BUILD_COMMANDS)
 


### PR DESCRIPTION
Useful for turning off any of the dynamic execution (install/build/test) to speed up running just the QL option -- since QL doesn't need any of the dependencies or any code execution

Thx @reallyTG for idea